### PR TITLE
Parallize mesos and singularity metrics collection

### DIFF
--- a/mesos_stats/singularity.py
+++ b/mesos_stats/singularity.py
@@ -1,23 +1,36 @@
+import time
+import functools
+from multiprocessing import Pool
 from .metric import Metric, Each
 from .util import log, try_get_json
-import time
+
+POOL_SIZE = 20 # Number of parallel processes to query singularity
 
 class Singularity:
     def __init__(self, host):
         self.host = host
         self.reset()
 
+
+    def show_cache_info(self):
+        log("_get cache info : {}".format(self._get.cache_info()))
+
+
     def state(self):
-        return self.__get("/state")
+        return self._get("/state")
+
 
     def active_requests(self):
-        return self.__get("/requests")
+        return self._get("/requests")
+
 
     def pending_deploys(self):
-        return self.__get("/deploys/pending")
+        return self._get("/deploys/pending")
+
 
     def failed_tasks(self, requestId):
-        return self.__get("/history/request/%s/tasks" % requestId)
+        return self._get("/history/request/%s/tasks" % requestId)
+
 
     # scheduled_tasks should nod be confused with the common concept of scheduled
     # tasks. This indicates any task which is scheduled to be run, including tasks
@@ -25,36 +38,56 @@ class Singularity:
     # or workers. All of these task types become a scheduled task prior to being
     # run on a slave.
     def scheduled_tasks(self):
-        return self.__get("/tasks/scheduled")
+        return self._get("/tasks/scheduled")
 
-    def __get(self, uri):
-        if self.__cache.get(uri) == None:
-            url = "http://%s/api%s" % (self.host, uri)
-            log("Getting %s" % url)
-            self.__cache[uri] = try_get_json(url)
-        return self.__cache[uri]
+
+    @functools.lru_cache(maxsize=None)
+    def _get(self, uri):
+        url = "http://%s/api%s" % (self.host, uri)
+        log("Getting %s" % url)
+        return try_get_json(url)
+
 
     def reset(self):
-        self.__cache = {}
+        self.show_cache_info()
+        self._get.cache_clear()
+
 
 class DigestedMetric:
     def __init__(self, key, value):
         self.key = key
         self.value = value
+
+
     def Results(self):
         return [(self.key, self.value)]
 
+def get_failed_count(request, singularity):
+    failed_tasks = singularity.failed_tasks(request['request']['id'])
+    count = 0
+    for h in failed_tasks:
+        # TODO: we should store the timestamp of the last scrape so we
+        # only filter by updatedAt > last_scrape_timestamp instead of
+        # hardcoding this to 1500 ms.
+        if all([h['lastTaskState'] == 'TASK_FAILED',
+               h['updatedAt'] > int(round((time.time() - 1500)* 1000)),
+               h['updatedAt'] < int(round((time.time())* 1000))]):
+            count += 1
+    return (request['request']['id'], count)
+
+
 def singularity_metrics(singularity):
-    # TODO: Figure out why deploy state is never OVERDUE, even when the deploy is
-    # overdue.
+    # TODO: Figure out why deploy state is never OVERDUE, even when the deploy
+    # is overdue.
     pending_deploys = singularity.pending_deploys()
-    #overdue_deploys = [d for d in pending_deploys if d["currentDeployState"] == "OVERDUE"]
+    #overdue_deploys = [d for d in pending_deploys
+    # if d["currentDeployState"] == "OVERDUE"]
 
-    # Alternative method to determine overdue tasks: look at scheduled start time
-    # and set to overdue if it is in the past. This is how the Singularity UI
-    # calculates it.
-    task_failed_count = {}
-
+    with Pool(processes=POOL_SIZE) as pool:
+        result = pool.map(functools.partial(get_failed_count,
+                                            singularity=singularity),
+                          singularity.active_requests())
+    '''
     for t in singularity.active_requests():
         failed_tasks = singularity.failed_tasks(t['request']['id'])
         for h in failed_tasks:
@@ -63,19 +96,26 @@ def singularity_metrics(singularity):
                     task_failed_count[h['taskId']['requestId']] += 1
                 else:
                     task_failed_count[h['taskId']['requestId']] = 1
-
+    '''
     scheduled_tasks = singularity.scheduled_tasks()
+
+    # Alternative method to determine overdue tasks: look at scheduled start
+    # time and set to overdue if it is in the past. This is how the
+    # Singularity UI calculates it.
     overdue_tasks = [t for t in scheduled_tasks if
             int(t["pendingTask"]["pendingTaskId"]["nextRunAt"]) <
             int(round(time.time() * 1000))]
 
     overdue_deploys = overdue_tasks
-    digested_metrics = [
-        DigestedMetric("singularity.deploys.pending.total", len(pending_deploys)),
-        DigestedMetric("singularity.deploys.pending.overdue", len(overdue_deploys)),
+    dm = [
+        DigestedMetric("singularity.deploys.pending.total",
+                       len(pending_deploys)),
+        DigestedMetric("singularity.deploys.pending.overdue",
+                       len(overdue_deploys)),
     ]
 
-    for requestId, count in task_failed_count.items():
-         digested_metrics.append(DigestedMetric("singularity.tasks.history.failure.%s"  % requestId, count))
+    for (requestId, count) in result:
+         dm.append(DigestedMetric("singularity.tasks.history.failure.%s"
+                                                        % requestId, count))
 
-    return digested_metrics
+    return dm


### PR DESCRIPTION
Some python PEP-8 compliance included as well. 

This PR cuts down metrics collection time by an order of magnitude. Original collection time running on my test host in India:

2017-11-20 07:06:43 Singularity metrics collection took 402.12307691574097s
2017-11-20 07:06:43 Entire collect and send cycle took 463.460275888443s

With this change:

2017-11-20 07:13:34 Singularity metrics collection took 24.482306957244873s
2017-11-20 07:13:34 Entire collect and send cycle took 34.093194007873535s
