### PR TITLE
Fix python 3 socket send to use encoding

### DIFF
--- a/mesos_stats.py
+++ b/mesos_stats.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python -u
 import os
 import sys
 import time
@@ -40,7 +39,8 @@ def init_env():
     print("==========================================")
 
     mesos = Mesos(master_pid)
-    carbon = Carbon(carbon_host, graphite_prefix, dry_run=dry_run)
+    carbon = Carbon(carbon_host, graphite_prefix,
+                    pickle=False, dry_run=dry_run)
 
     if singularity_host:
         singularity = Singularity(singularity_host)


### PR DESCRIPTION
this was failing in python 3 since strings in Python 3 are unicode. So we will need to encode this before sending it out.

Note that pickle does not work yet. Investigating why.