### PR TITLE
SRE-242 : Refactor

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,8 @@ url = "https://pypi.python.org/simple"
 [packages]
 
 requests = "*"
+httpretty = "*"
+requests-mock = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a0e63f8a0d1e3df046dc19b3ffbaaedfa151afc12af5a5b960ae7393952f8679"
+            "sha256": "ee0f980543a3844942fe8798dcb72758426553b2c8c8f01166f18b98a38fc006"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
@@ -41,6 +41,13 @@
             ],
             "version": "==3.0.4"
         },
+        "httpretty": {
+            "hashes": [
+                "sha256:cf51d23dae21b4da2c083a6efa381f5ab967d61095e45de1123f358812024237",
+                "sha256:83c176bbac9d68a45a5cca54f2d5be7e6b16a063adf6f334e7fd0eee272e976e"
+            ],
+            "version": "==0.8.14"
+        },
         "idna": {
             "hashes": [
                 "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
@@ -54,6 +61,20 @@
                 "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
             ],
             "version": "==2.18.4"
+        },
+        "requests-mock": {
+            "hashes": [
+                "sha256:96a1e45b1c0bd18d14fcb2d55b3b09d6d46237e37bcae3155df4cb75bc42619e",
+                "sha256:2931887853c42e1d73879983d5bf03041109472991c5b4b8dba5d11ed23b9d0b"
+            ],
+            "version": "==1.4.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+            ],
+            "version": "==1.11.0"
         },
         "urllib3": {
             "hashes": [

--- a/mesos_stats.py
+++ b/mesos_stats.py
@@ -2,7 +2,6 @@ import os
 import sys
 import time
 import traceback
-import pprint
 import queue
 from datetime import datetime
 
@@ -18,11 +17,12 @@ from mesos_stats.singularity import Singularity, SingularityCarbon
 
 def str_to_bool(s):
     if s == 'True':
-         return True
+        return True
     elif s == 'False':
-         return False
+        return False
     else:
-         raise ValueError
+        raise ValueError
+
 
 def init_env():
     master_list = os.environ['MESOS_MASTER'].split(',')
@@ -38,7 +38,6 @@ def init_env():
 
     if not all([master_list, carbon_host, graphite_prefix]):
         print('One or more configuration env not set')
-        print_config()
         sys.exit(0)
 
     print("Got configuration...")
@@ -60,6 +59,7 @@ def init_env():
 
     return (mesos, carbon, singularity, carbon_pickle)
 
+
 def wait_until_beginning_of_clock_minute():
     iter_start = time.time()
     now = datetime.fromtimestamp(iter_start)
@@ -71,22 +71,19 @@ def wait_until_beginning_of_clock_minute():
 def main_loop(mesos, carbon, singularity, pickle):
     should_exit = False
     # self-monitoring
-    last_cycle_time = 0
-    last_collection_time = 0
-    last_send_time = 0
-    assert all([mesos, carbon]) # Mesos and Carbon is mandatory
+    assert all([mesos, carbon])  # Mesos and Carbon is mandatory
 
     metrics_queue = queue.Queue()
     if singularity:
         singularity_carbon = SingularityCarbon(singularity, metrics_queue,
-                                              pickle)
+                                               pickle)
         mesos_carbon = MesosCarbon(mesos, metrics_queue, singularity, pickle)
     else:
         mesos_carbon = MesosCarbon(mesos, metrics_queue, pickle=pickle)
 
     while True:
         try:
-            #wait_until_beginning_of_clock_minute()
+            # wait_until_beginning_of_clock_minute()
             with Timer("Entire collect and send cycle"):
                 timestamp = time.time()
                 now = datetime.fromtimestamp(timestamp)

--- a/mesos_stats.py
+++ b/mesos_stats.py
@@ -2,52 +2,63 @@ import os
 import sys
 import time
 import traceback
+import pprint
+import queue
 from datetime import datetime
 
 from mesos_stats.util import log, Timer
 from mesos_stats.mesos import (
-    cluster_metrics,
     Mesos,
+    MesosCarbon,
     MesosStatsException,
-    slave_metrics,
-    slave_task_metrics,
 )
 from mesos_stats.carbon import Carbon
-from mesos_stats.singularity import Singularity, singularity_metrics
+from mesos_stats.singularity import Singularity, SingularityCarbon
 
+
+def str_to_bool(s):
+    if s == 'True':
+         return True
+    elif s == 'False':
+         return False
+    else:
+         raise ValueError
 
 def init_env():
-    master_host = os.environ['MESOS_MASTER']
+    master_list = os.environ['MESOS_MASTER'].split(',')
     carbon_host = os.environ['CARBON_HOST']
     graphite_prefix = os.environ['GRAPHITE_PREFIX']
+    carbon_pickle = os.environ.get('CARBON_PICKLE', 'False')
     singularity_host = os.environ.get('SINGULARITY_HOST', None)
     carbon_port = os.environ.get('CARBON_PORT', '2003')
-    dry_run = os.environ.get('DRY_RUN', False)
-    if dry_run == 'False':
-        dry_run = False
-    master_pid = "%s:5050" % master_host
+    dry_run = os.environ.get('DRY_RUN', 'False')
 
-    if not all([master_host, carbon_host, graphite_prefix]):
+    dry_run = str_to_bool(dry_run)
+    carbon_pickle = str_to_bool(carbon_pickle)
+
+    if not all([master_list, carbon_host, graphite_prefix]):
         print('One or more configuration env not set')
         print_config()
         sys.exit(0)
 
     print("Got configuration...")
-    print("MESOS MASTER:     %s" % master_pid)
+    print("MESOS MASTERS:     %s" % master_list)
     print("CARBON:           %s" % carbon_host)
     print("GRAPHITE PREFIX:  %s" % graphite_prefix)
+    print("CARBON PICKLE:  %s" % carbon_pickle)
     print("SINGULARITY HOST: %s" % singularity_host)
     print("DRY RUN (TEST MODE): %s" % dry_run)
     print("==========================================")
 
-    mesos = Mesos(master_pid)
+    assert(isinstance(master_list, list))
+    mesos = Mesos(master_list)
     carbon = Carbon(carbon_host, graphite_prefix, port=int(carbon_port),
-                    pickle=False, dry_run=dry_run)
+                    pickle=carbon_pickle, dry_run=dry_run)
 
     if singularity_host:
         singularity = Singularity(singularity_host)
 
-    return (mesos, carbon, singularity)
+    return (mesos, carbon, singularity, carbon_pickle)
 
 def wait_until_beginning_of_clock_minute():
     iter_start = time.time()
@@ -56,43 +67,49 @@ def wait_until_beginning_of_clock_minute():
     log("Sleeping for %ss" % sleep_time)
     time.sleep(sleep_time)
 
-def main_loop(mesos, carbon, singularity):
+
+def main_loop(mesos, carbon, singularity, pickle):
     should_exit = False
     # self-monitoring
     last_cycle_time = 0
     last_collection_time = 0
     last_send_time = 0
     assert all([mesos, carbon]) # Mesos and Carbon is mandatory
+
+    metrics_queue = queue.Queue()
+    if singularity:
+        singularity_carbon = SingularityCarbon(singularity, metrics_queue,
+                                              pickle)
+        mesos_carbon = MesosCarbon(mesos, metrics_queue, singularity, pickle)
+    else:
+        mesos_carbon = MesosCarbon(mesos, metrics_queue, pickle=pickle)
+
     while True:
         try:
-            wait_until_beginning_of_clock_minute()
+            #wait_until_beginning_of_clock_minute()
             with Timer("Entire collect and send cycle"):
                 timestamp = time.time()
                 now = datetime.fromtimestamp(timestamp)
                 log("Timestamp: %s (%s)" % (now, timestamp))
                 cycle_timeout = timestamp + 59.0
-                metrics = []
-                if mesos:
-                    with Timer("Mesos metrics collection"):
-                        mesos.reset()
-                        metrics.extend(slave_metrics(mesos))
-                        if singularity:
-                            metrics.extend(slave_task_metrics(mesos,
-                                        singularity.active_requests()))
-                        else:
-                            metrics.extend(slave_task_metrics(mesos))
-                        metrics.extend(cluster_metrics(mesos))
                 if singularity:
                     with Timer("Singularity metrics collection"):
                         singularity.reset()
-                        metrics.extend(singularity_metrics(singularity))
-                if not metrics:
+                        singularity.update()
+                        singularity_carbon.flush_all()
+                if mesos:
+                    with Timer("Mesos metrics collection"):
+                        mesos.reset()
+                        mesos.update()
+                        mesos_carbon.flush_all()
+                if not metrics_queue:
                     log("No stats this time; sleeping")
-                else:
-                    send_timeout = cycle_timeout - time.time()
-                    log("Sending stats (timeout %ss)" % send_timeout)
-                    with Timer("Sending stats to graphite"):
-                        carbon.send_metrics(metrics, send_timeout, timestamp)
+                    continue
+
+                send_timeout = cycle_timeout - time.time()
+                log("Sending stats (timeout %ss)" % send_timeout)
+                with Timer("Sending stats to graphite"):
+                    carbon.send_metrics(metrics_queue, send_timeout)
         except MesosStatsException as e:
             log("%s" % e)
         except (KeyboardInterrupt, SystemExit):
@@ -115,12 +132,13 @@ def main_loop(mesos, carbon, singularity):
             if should_exit:
                 return
 
+
 if __name__ == '__main__':
-    (mesos, carbon, singularity) = init_env()
+    (mesos, carbon, singularity, pickle) = init_env()
     start_time = time.time()
     print("Start time: %s" % datetime.fromtimestamp(start_time))
     try:
-        main_loop(mesos, carbon, singularity)
+        main_loop(mesos, carbon, singularity, pickle)
     except (KeyboardInterrupt, SystemExit):
         print("Bye!")
         sys.exit(0)

--- a/mesos_stats.py
+++ b/mesos_stats.py
@@ -83,7 +83,7 @@ def main_loop(mesos, carbon, singularity, pickle):
 
     while True:
         try:
-            # wait_until_beginning_of_clock_minute()
+            wait_until_beginning_of_clock_minute()
             with Timer("Entire collect and send cycle"):
                 timestamp = time.time()
                 now = datetime.fromtimestamp(timestamp)

--- a/mesos_stats/carbon.py
+++ b/mesos_stats/carbon.py
@@ -1,13 +1,11 @@
 import socket
 import struct
-import time
-import os
-import sys
 import pickle
 import queue
 from mesos_stats.util import log
 
-CHUNK_SIZE = 5000 # Maximum number of stats to send to Carbon in one go
+CHUNK_SIZE = 5000  # Maximum number of stats to send to Carbon in one go
+
 
 class Carbon:
     def __init__(self, host, prefix, pickle=False, port=2003,
@@ -21,33 +19,28 @@ class Carbon:
         self.dry_run = dry_run
         self.timeout = 30.0
 
-
     def connect(self, port):
-        if self.sock != None:
+        if self.sock is not None:
             raise Exception("Attempt to connect an already connected socket.")
         self.port = port
         self.sock = socket.socket()
         self.sock.settimeout(self.timeout)
         self.sock.connect((self.host, self.port))
 
-
     def ensure_connected(self, port):
-        if self.sock == None:
+        if self.sock is None:
             self.connect(port)
         elif self.port != port:
             self.close()
             self.sock.connect(port)
-
 
     def close(self):
         if self.sock:
             self.sock.close()
             self.sock = None
 
-
     def send_metrics(self, metrics, timeout):
         self.timeout = timeout
-        data = []
         iterations = 1
         total = 0
         while True:
@@ -66,14 +59,12 @@ class Carbon:
         log('Sent {} datapoints to Carbon'.format(total))
         self.close()
 
-
     def _add_prefix(self, metric):
         if self.pickle:
             return ('{}.{}'.format(self.prefix, metric[0]),
                     (metric[1][0], metric[1][1]))
         else:
             return '{}.{}'.format(self.prefix, metric)
-
 
     def _get_chunk_from_queue(self, q, n):
         '''
@@ -94,19 +85,16 @@ class Carbon:
                 break
         return res
 
-
     def send_metrics_plaintext(self, metrics_list):
         log('Send metrics via Plaintext')
         self.ensure_connected(self.port)
 
         data = []
-        iterations = 0
         data = "\n".join(metrics_list) + '\n'
         sent = self.sock.sendall(data.encode())
         if sent == 0:
             raise RuntimeError("socket connection broken")
         return
-
 
     def send_metrics_pickle(self, metrics_list):
         log('Send metrics via Pickle')
@@ -117,4 +105,3 @@ class Carbon:
         message = header + payload
         self.sock.send(message)
         return
-

--- a/mesos_stats/carbon.py
+++ b/mesos_stats/carbon.py
@@ -4,7 +4,7 @@ import pickle
 import queue
 from mesos_stats.util import log
 
-CHUNK_SIZE = 5000  # Maximum number of stats to send to Carbon in one go
+CHUNK_SIZE = 500  # Maximum number of stats to send to Carbon in one go
 
 
 class Carbon:
@@ -86,7 +86,7 @@ class Carbon:
         return res
 
     def send_metrics_plaintext(self, metrics_list):
-        log('Send metrics via Plaintext')
+        log('Sending {} metrics via Plaintext'.format(len(metrics_list)))
         self.ensure_connected(self.port)
 
         data = []

--- a/mesos_stats/carbon.py
+++ b/mesos_stats/carbon.py
@@ -4,8 +4,8 @@ import time
 import os
 import sys
 import pickle
+import queue
 from mesos_stats.util import log
-from mesos_stats.metric import Metric
 
 CHUNK_SIZE = 5000 # Maximum number of stats to send to Carbon in one go
 
@@ -21,6 +21,7 @@ class Carbon:
         self.dry_run = dry_run
         self.timeout = 30.0
 
+
     def connect(self, port):
         if self.sock != None:
             raise Exception("Attempt to connect an already connected socket.")
@@ -29,6 +30,7 @@ class Carbon:
         self.sock.settimeout(self.timeout)
         self.sock.connect((self.host, self.port))
 
+
     def ensure_connected(self, port):
         if self.sock == None:
             self.connect(port)
@@ -36,70 +38,83 @@ class Carbon:
             self.close()
             self.sock.connect(port)
 
+
     def close(self):
-        self.sock.close()
-        self.sock = None
+        if self.sock:
+            self.sock.close()
+            self.sock = None
 
-    def send_metrics(self, metrics, timeout, timestamp):
-        num_datapoints = sum([len(m.data) if isinstance(m, Metric) else 1
-                              for m in metrics])
-        log('Sending {} datapoints to Carbon'.format(num_datapoints))
-        if self.dry_run: # Don't do anything in test mode
-            log('DRY RUN - Not sending stats to carbon')
-            return
+
+    def send_metrics(self, metrics, timeout):
         self.timeout = timeout
-        ts = int(timestamp)
+        data = []
+        iterations = 1
+        total = 0
+        while True:
+            chunk = self._get_chunk_from_queue(metrics, CHUNK_SIZE)
+            if not self.dry_run:
+                if self.pickle:
+                    self.send_metrics_pickle(chunk)
+                else:
+                    self.send_metrics_plaintext(chunk)
+            iterations += 1
+            total += len(chunk)
+            if len(chunk) < CHUNK_SIZE:
+                break
+        if iterations != 1:
+            log("INFO: Send took %s iterations" % iterations)
+        log('Sent {} datapoints to Carbon'.format(total))
+        self.close()
+
+
+    def _add_prefix(self, metric):
         if self.pickle:
-            self.send_metrics_pickle(metrics, ts)
-            return
+            return ('{}.{}'.format(self.prefix, metric[0]),
+                    (metric[1][0], metric[1][1]))
         else:
-            self.send_metrics_plaintext(metrics, ts)
+            return '{}.{}'.format(self.prefix, metric)
 
-    def _chunks(self, l, n):
-        """Yield successive n-sized chunks from l."""
-        for i in range(0, len(l), n):
-            yield l[i:i + n]
 
-    def send_metrics_plaintext(self, metrics, ts):
+    def _get_chunk_from_queue(self, q, n):
+        '''
+        returns list with n number of metrics from queue
+        if queue has less than n metrics, it will return everything
+        optionally adds a prefix to the metric name
+        '''
+        res = []
+        while True:
+            try:
+                m = q.get(block=False)
+            except queue.Empty:
+                break
+            if self.prefix:
+                m = self._add_prefix(m)
+            res.append(m)
+            if len(res) == n:
+                break
+        return res
+
+
+    def send_metrics_plaintext(self, metrics_list):
         log('Send metrics via Plaintext')
-        try:
-            self.ensure_connected(self.port)
-            self.all_stats = []
-            for m in metrics:
-                for k, v in m.Results():
-                    self.all_stats.append("{}.{} {} {}".format(self.prefix,
-                                                               k, v, ts))
-            l = len(self.all_stats)
-            iterations = 0
-            for chunk in self._chunks(self.all_stats, CHUNK_SIZE):
-                iterations += 1
-                data = "\n".join(chunk) + '\n'
-                sent = self.sock.sendall(data.encode())
-                if sent == 0:
-                    raise RuntimeError("socket connection broken")
-            if iterations != 1:
-                log("INFO: Send took %s iterations" % iterations)
-        finally:
-            self.close()
+        self.ensure_connected(self.port)
 
-    def send_metrics_pickle(self, metrics, ts):
+        data = []
+        iterations = 0
+        data = "\n".join(metrics_list) + '\n'
+        sent = self.sock.sendall(data.encode())
+        if sent == 0:
+            raise RuntimeError("socket connection broken")
+        return
+
+
+    def send_metrics_pickle(self, metrics_list):
         log('Send metrics via Pickle')
-        try:
-            self.ensure_connected(self.pickle_port)
-            tuples = []
-            ts = int(time.time())
-            def addToTuple(k, v):
-                tuples.append((k, (ts, v)))
-            self.forEachPrefixedMetric(metrics, addToTuple)
-            payload = pickle.dumps(tuples, protocol=2)
-            header = struct.pack("!L", len(payload))
-            message = header + payload
-            self.sock.send(message)
-        finally:
-            self.close()
+        self.ensure_connected(self.pickle_port)
+        assert(isinstance(metrics_list[0], tuple))
+        payload = pickle.dumps(metrics_list, protocol=2)
+        header = struct.pack("!L", len(payload))
+        message = header + payload
+        self.sock.send(message)
+        return
 
-    def forEachPrefixedMetric(self, metrics, f):
-        for m in metrics:
-            for r in m.Results():
-                k, v = r
-                f(self.prefix + "." + k, v)

--- a/mesos_stats/mesos.py
+++ b/mesos_stats/mesos.py
@@ -233,18 +233,21 @@ class MesosCarbon:
                                                           instance))
                 return '{}-{}_{}'.format(task_name, env, instance)
         if '-teamcity_' in name:
+            # matches ci-nei-teamcity_2018_01_04T12_4-1-mesos_slave4_qa_sf
             pattern = '(\S+)-teamcity\S+-(\d+)-mesos_\S+'
             match = re.search(pattern, name)
             if match:
                 task_name, instance = match.groups()
                 log('guessed task name : {}_{}'.format(task_name, instance))
                 return '{}_{}'.format(task_name, instance)
-        if 'opentable.com' in name and '_20' in name:
+        if 'opentable.com' in name:
+            pattern = '(\S+)(_|-\.)20\d{2}.\S+-(\d+)-mesos_\S+'
             # Matches task_name_2018-01-02-1-mesos-slave-14.opentable.com
-            pattern = '(\S+)_20\S+-(\d+)-mesos_\S+'
+            # OR
+            # Matches task_name-.2018-01-02-1-mesos-slave-14.opentable.com
             match = re.search(pattern, name)
             if match:
-                task_name, env, instance = match.groups()
+                task_name, _, instance = match.groups()
                 log('guessed task name : {}_{}'.format(task_name, instance))
                 return '{}_{}'.format(task_name, instance)
         log('Could not guess task name for : {}'.format(name))

--- a/mesos_stats/mesos.py
+++ b/mesos_stats/mesos.py
@@ -54,7 +54,8 @@ class Mesos:
         if self.slaves:
             self.slave_metrics = self._get_slave_metrics()
             self.executors = self._get_executors()
-            log('Total number of executors = {}'.format(sum(len(e) for e in self.executors)))
+            log('Total number of executors = {}'.format(sum(len(e)
+                                            for e in self.executors)))
 
 
     def _get_cluster_metrics(self):
@@ -220,9 +221,10 @@ class MesosCarbon:
         for slave_name, executors in self.mesos.executors.items():
             for e in executors:
                 for k, v in e['statistics'].items():
+                    task_name = self._clean_metric_name(e['executor_id'])
                     try:
                         metric_name = self.executor_metric_mapping[k]\
-                                .format(slave_name, e['executor_id'])
+                                .format(slave_name, task_name)
                     except KeyError:
                         continue
                     self._add_to_queue(metric_name, v)
@@ -256,6 +258,8 @@ class MesosCarbon:
                                                e['executor_id'])
                 else: # Use mesos task names for non singularity tasks
                     task_name = e['executor_id']
+
+                task_name = self._clean_metric_name(task_name)
 
                 for k, v in e['statistics'].items():
                     try:

--- a/mesos_stats/mesos.py
+++ b/mesos_stats/mesos.py
@@ -240,6 +240,8 @@ class MesosCarbon:
                     task_name = sing_lookup.get(e['executor_id'],
                                                 e['executor_id'])
                 else:  # Use mesos task names for non singularity tasks
+                    log('Could not find request name for : {}'
+                        .format(e['executor_id']))
                     task_name = e['executor_id']
 
                 task_name = self._clean_metric_name(task_name)

--- a/mesos_stats/mesos.py
+++ b/mesos_stats/mesos.py
@@ -207,9 +207,10 @@ class MesosCarbon:
             for e in executors:
                 for k, v in e['statistics'].items():
                     task_name = self._clean_metric_name(e['executor_id'])
+                    sn = self._clean_metric_name(slave_name)
                     try:
                         metric_name = self.executor_metric_mapping[k]\
-                                .format(slave_name, task_name)
+                                .format(sn, task_name)
                     except KeyError:
                         continue
                     self._add_to_queue(metric_name, v)

--- a/mesos_stats/metric.py
+++ b/mesos_stats/metric.py
@@ -1,7 +1,7 @@
 
 class Metric:
     def __init__(self, path, name, *measurements):
-        if measurements == None or len(measurements) == 0:
+        if measurements is None or len(measurements) == 0:
             measurements = [Each()]
         self.name = name
         self.path = path
@@ -9,7 +9,7 @@ class Metric:
         self.data = []
 
     def Add(self, datum, keys=[]):
-        if datum == None:
+        if datum is None:
             return
         self.data.append((datum[self.path], keys))
 
@@ -29,6 +29,7 @@ class Metric:
             results += f(self)
         return results
 
+
 def Each(scale=1):
     def Each_scale(metric):
         results = []
@@ -37,4 +38,3 @@ def Each(scale=1):
             results.append(metric.Datapoint(keys, d*scale))
         return results
     return Each_scale
-

--- a/mesos_stats/singularity.py
+++ b/mesos_stats/singularity.py
@@ -91,7 +91,7 @@ class SingularityCarbon:
         self.pickle = pickle
 
 
-    def flush_metrics(self):
+    def flush_all(self):
         counter = 0
         # flush state metrics
         for k, v in self.singularity.state.items():
@@ -122,6 +122,6 @@ class SingularityCarbon:
         # The pickle protocol accepts a tuple
         # [(path, (timestamp, value)), ...]
         if not self.pickle:
-            self.queue.append('{} {} {}'.format(metric_name, metric_value, ts))
+            self.queue.put('{} {} {}'.format(metric_name, metric_value, ts))
         else:
-            self.queue.append((metric_name, (ts, metric_value)))
+            self.queue.put((metric_name, (ts, metric_value)))

--- a/mesos_stats/singularity.py
+++ b/mesos_stats/singularity.py
@@ -1,111 +1,103 @@
 import time
-import functools
-from multiprocessing import Pool
-from .metric import Metric, Each
 from .util import log, try_get_json
-
-POOL_SIZE = 10 # Number of parallel processes to query singularity
 
 class Singularity:
     def __init__(self, host):
         self.host = host
-        self.reset()
+        self.update()
+
+    def reset(self):
+        self.state = None
+        self.active_requests = None
+        self.disasters_stats = None
+
+    def update(self):
+        self.state = self.get_state()
+        self.active_requests = self.get_active_requests()
+        self.disasters_stats = self.get_disasters_stats()
 
 
-    def show_cache_info(self):
-        log("_get cache info : {}".format(self._get.cache_info()))
+    def get_disasters_stats(self):
+        return self._get("/disasters/stats")
 
 
-    def state(self):
+    def get_state(self):
         return self._get("/state")
 
 
-    def active_requests(self):
+    def get_active_requests(self):
         return self._get("/requests")
 
 
-    def pending_deploys(self):
-        return self._get("/deploys/pending")
-
-
-    def failed_tasks(self, requestId):
-        return self._get("/history/request/%s/tasks" % requestId)
-
-
-    # scheduled_tasks should nod be confused with the common concept of scheduled
-    # tasks. This indicates any task which is scheduled to be run, including tasks
-    # which have been invoked to run immediately, and long-running services
-    # or workers. All of these task types become a scheduled task prior to being
-    # run on a slave.
-    def scheduled_tasks(self):
-        return self._get("/tasks/scheduled")
-
-
-    @functools.lru_cache(maxsize=None)
     def _get(self, uri):
         url = "http://%s/api%s" % (self.host, uri)
         #log("Getting %s" % url)
         return try_get_json(url)
 
 
-    def reset(self):
-        self.show_cache_info()
-        self._get.cache_clear()
+class SingularityCarbon:
+    '''
+        Convert Singularity metrics into Carbon compatible metrics
+        and flushes them into the give queue
+    '''
+    metric_mapping = {
+        "activeTasks":              "singularity.tasks.active",
+        "scheduledTasks":           "singularity.tasks.scheduled",
+        "lateTasks":                "singularity.tasks.late",
+        "launchingTasks":           "singularity.tasks.launching",
+        "cleaningTasks":            "singularity.tasks.cleaning",
+        "futureTasks":              "singularity.tasks.future",
+        "numLostTasks":             "singularity.tasks.lost",
+        "avgTaskLagMillis":         "singularity.tasks.avg_lag_millis",
+        "activeRequests":           "singularity.requests.active",
+        "cooldownRequests":         "singularity.requests.cooldown",
+        "pausedRequests":           "singularity.requests.paused",
+        "pendingRequests":          "singularity.requests.pending",
+        "cleaningRequests":         "singularity.requests.cleaning",
+        "activeSlaves":             "singularity.slaves.active",
+        "deadSlaves":               "singularity.slaves.dead",
+        "numLostSlaves":            "singularity.slaves.lost",
+        "decommissioningSlaves":    "singularity.slaves.decommissioning",
+    }
 
 
-class DigestedMetric:
-    def __init__(self, key, value):
-        self.key = key
-        self.value = value
+    def __init__(self, singularity, queue, pickle=False):
+        self.singularity = singularity
+        self.queue = queue
+        self.pickle = pickle
 
 
-    def Results(self):
-        return [(self.key, self.value)]
+    def flush_metrics(self):
+        counter = 0
+        # flush state metrics
+        for k, v in self.singularity.state.items():
+            try:
+                metric_name = self.metric_mapping[k]
+            except KeyError:
+                continue
+            ts = int(time.time())
+            self._add_to_queue(metric_name, v, ts)
+            counter += 1
+        # flush disaster metrics
+        latest_stat = self.singularity.disasters_stats.get('stats')[0]
+        ts = latest_stat.get('timestamp')
+        for k, v in latest_stat.items():
+            try:
+                metric_name = self.metric_mapping[k]
+            except KeyError:
+                continue
+            self._add_to_queue(metric_name, v, ts)
+            counter += 1
 
-def get_failed_count(request, singularity):
-    failed_tasks = singularity.failed_tasks(request['request']['id'])
-    count = 0
-    for h in failed_tasks:
-        # TODO: we should store the timestamp of the last scrape so we
-        # only filter by updatedAt > last_scrape_timestamp instead of
-        # hardcoding this to 1500 ms.
-        if all([h['lastTaskState'] == 'TASK_FAILED',
-               h['updatedAt'] > int(round((time.time() - 1500)* 1000)),
-               h['updatedAt'] < int(round((time.time())* 1000))]):
-            count += 1
-    return (request['request']['id'], count)
+        log('flushed {} singularity metrics'.format(counter))
 
 
-def singularity_metrics(singularity):
-    # TODO: Figure out why deploy state is never OVERDUE, even when the deploy
-    # is overdue.
-    pending_deploys = singularity.pending_deploys()
-    #overdue_deploys = [d for d in pending_deploys
-    # if d["currentDeployState"] == "OVERDUE"]
-
-    with Pool(processes=POOL_SIZE) as pool:
-        result = pool.map(functools.partial(get_failed_count,
-                                            singularity=singularity),
-                          singularity.active_requests())
-    scheduled_tasks = singularity.scheduled_tasks()
-
-    # Alternative method to determine overdue tasks: look at scheduled start
-    # time and set to overdue if it is in the past. This is how the
-    # Singularity UI calculates it.
-    overdue_tasks = [t for t in scheduled_tasks if
-            int(t["pendingTask"]["pendingTaskId"]["nextRunAt"]) <
-            int(round(time.time() * 1000))]
-
-    overdue_deploys = overdue_tasks
-    dm = [
-        DigestedMetric("singularity.deploys.pending.total",
-                       len(pending_deploys)),
-        DigestedMetric("singularity.deploys.pending.overdue",
-                       len(overdue_deploys)),
-    ]
-
-    for (requestId, count) in result:
-         dm.append(DigestedMetric("singularity.tasks.history.failure.%s"
-                                                        % requestId, count))
-
-    return dm
+    def _add_to_queue(self, metric_name, metric_value, ts):
+        # The carbon plaintext protocol for metrics are
+        # <metric path> <metric value> <metric timestamp>
+        # The pickle protocol accepts a tuple
+        # [(path, (timestamp, value)), ...]
+        if not self.pickle:
+            self.queue.append('{} {} {}'.format(metric_name, metric_value, ts))
+        else:
+            self.queue.append((metric_name, (ts, metric_value)))

--- a/mesos_stats/singularity.py
+++ b/mesos_stats/singularity.py
@@ -35,6 +35,9 @@ class Singularity:
     def get_active_tasks(self):
         return self._get("/tasks/active")
 
+    def get_scheduled_tasks(self):
+        return self._get("/tasks/scheduled")
+
     def _get(self, uri):
         url = "http://%s/api%s" % (self.host, uri)
         return try_get_json(url)

--- a/mesos_stats/singularity.py
+++ b/mesos_stats/singularity.py
@@ -1,6 +1,7 @@
 import time
 from .util import log, try_get_json
 
+
 class Singularity:
     def __init__(self, host):
         self.host = host
@@ -22,28 +23,21 @@ class Singularity:
         self.disasters_stats = self.get_disasters_stats()
         self.active_tasks = self.get_active_tasks()
 
-
     def get_disasters_stats(self):
         return self._get("/disasters/stats")
-
 
     def get_state(self):
         return self._get("/state")
 
-
     def get_active_requests(self):
         return self._get("/requests")
-
 
     def get_active_tasks(self):
         return self._get("/tasks/active")
 
-
     def _get(self, uri):
         url = "http://%s/api%s" % (self.host, uri)
-        #log("Getting %s" % url)
         return try_get_json(url)
-
 
     def get_singularity_lookup(self):
         '''
@@ -84,12 +78,10 @@ class SingularityCarbon:
         "decommissioningSlaves":    "singularity.slaves.decommissioning",
     }
 
-
     def __init__(self, singularity, queue, pickle=False):
         self.singularity = singularity
         self.queue = queue
         self.pickle = pickle
-
 
     def flush_all(self):
         counter = 0
@@ -114,7 +106,6 @@ class SingularityCarbon:
             counter += 1
 
         log('flushed {} singularity metrics'.format(counter))
-
 
     def _add_to_queue(self, metric_name, metric_value, ts):
         # The carbon plaintext protocol for metrics are

--- a/mesos_stats/util.py
+++ b/mesos_stats/util.py
@@ -3,6 +3,7 @@ import time
 import sys
 import requests
 
+
 def try_get_json(url, timeout=20):
     t = time.time()
     try:
@@ -26,14 +27,18 @@ def try_get_json(url, timeout=20):
         log("GET %s failed - Non 200 HTTP Error" % url)
         return False
 
+
 def log(message):
     ts = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
     print('%s %s' % (ts, message))
 
+
 class Timer:
     def __init__(self, name):
         self.name = name
+
     def __enter__(self):
         self.time = time.time()
+
     def __exit__(self, type, value, traceback):
         return log("%s took %ss" % (self.name, time.time() - self.time))

--- a/test/carbon_test.py
+++ b/test/carbon_test.py
@@ -1,0 +1,28 @@
+import unittest
+import queue
+from mesos_stats.carbon import Carbon
+
+class CarbonTest(unittest.TestCase):
+    def test_add_prefix(self):
+        c = Carbon('127.0.0.1', 'myprefix.abc')
+        a = "a.b 123 1111"
+        self.assertEqual(c._add_prefix(a), 'myprefix.abc.a.b 123 1111')
+
+
+    def test_add_prefix_pickle(self):
+        c = Carbon('127.0.0.1', 'myprefix.abc', pickle=True)
+        a = ('a.b', (123, 1111))
+        self.assertEqual(c._add_prefix(a),
+                         ('myprefix.abc.a.b', (123, 1111))
+        )
+
+    def test_get_chunk_from_queue(self):
+        c = Carbon('127.0.0.1', prefix=None, pickle=False)
+        q = queue.Queue()
+        for i in [1, 2, 3, 4, 5]:
+            q.put(i, block=False)
+        a = c._get_chunk_from_queue(q, 2)
+        self.assertEqual(len(a), 2)
+        a = c._get_chunk_from_queue(q, 100)
+        self.assertEqual(len(a), 3)
+

--- a/test/mesos_test.py
+++ b/test/mesos_test.py
@@ -123,6 +123,10 @@ class MesosTest(unittest.TestCase):
         self.assertEqual(mc._best_guess_req_name(name),
                          'ci-custom-messages-sync_1')
 
+        name = 'ci-waitlist-worker-.2016.11.03T16.16.59-1519659540491-2-mesos_slave9_qa_sf.qasql.opentable.com-FIXME'
+        self.assertEqual(mc._best_guess_req_name(name),
+                         'ci-waitlist-worker_2')
+
         # Test that the percent is scaled up by 100, 0.1 * 100 = 10.0
         b = q.get()
         self.assertEqual(b.split()[1], '10.0')

--- a/test/mesos_test.py
+++ b/test/mesos_test.py
@@ -1,6 +1,4 @@
-import time
 import unittest
-import requests
 import multiprocessing
 import requests_mock
 
@@ -16,6 +14,7 @@ stream_handler = logging.StreamHandler(sys.stdout)
 logger.addHandler(stream_handler)
 '''
 
+
 class MesosTest(unittest.TestCase):
     def setUp(self):
         self.slaves_api = {
@@ -27,13 +26,9 @@ class MesosTest(unittest.TestCase):
             ]
         }
 
-
-
-
     def test_mesos_raises_exception_for_no_master(self):
         master_list = ['mesos4', 'mesos5', 'mesos6']
         self.assertRaises(MesosStatsException, Mesos, master_list)
-
 
     def test_mesos_chooses_working_master(self):
         with requests_mock.Mocker(real_http=True) as m:
@@ -47,7 +42,6 @@ class MesosTest(unittest.TestCase):
                            json={'master/elected': 1}, status_code=200)
             mesos = Mesos(master_list=['mesos1', 'mesos2', 'mesos3'])
         self.assertEqual(mesos.master, 'mesos3')
-
 
     def test_get_slave_metrics(self):
         with requests_mock.Mocker(real_http=True) as m:
@@ -69,7 +63,6 @@ class MesosTest(unittest.TestCase):
             self.assertTrue('slave1' in slave_metrics.keys())
             self.assertTrue(isinstance(slave_metrics['slave1'], dict))
             self.assertTrue(slave_metrics['slave1']['slave/cpus_total'], 32)
-
 
     def test_mesoscarbon(self):
         with requests_mock.Mocker(real_http=True) as m:
@@ -115,11 +108,20 @@ class MesosTest(unittest.TestCase):
 
         try:
             self.assertTrue(q.qsize())
-        except NotImplementedError: # Not supported in Mac OS X
+        except NotImplementedError:  # Not supported in Mac OS X
             pass
         a = q.get()
         self.assertEqual(a.split()[0], 'slave.slave1.cpus.total')
         self.assertEqual(a.split()[1], '32')
+
+        # Test guessing request name
+        name = 'mobile_web_api---pp_sf-1612b9a643942c3eaf9c3b3bd8845aff-1_0_20_f57ac6cc7c894af1a62130618b12baff-1518165603653-2-mesos_slave8_qa_sf.qasql.opentable.com-FIXME'
+        self.assertEqual(mc._best_guess_req_name(name),
+                         'mobile_web_api-pp_sf_2')
+
+        name = 'ci-custom-messages-sync-teamcity_2018_02_19T10_56_48-1519398600781-1-mesos_slave14_qa_sf_qasql_opentable_com-FIXME'
+        self.assertEqual(mc._best_guess_req_name(name),
+                         'ci-custom-messages-sync_1')
 
         # Test that the percent is scaled up by 100, 0.1 * 100 = 10.0
         b = q.get()
@@ -134,7 +136,7 @@ class MesosTest(unittest.TestCase):
 
         try:
             self.assertTrue(q2.qsize())
-        except NotImplementedError: # Not supported in Mac OS X
+        except NotImplementedError:  # Not supported in Mac OS X
             pass
         a = q2.get()
         self.assertEqual(a.split()[0], 'cluster.cpus.total')
@@ -199,22 +201,22 @@ class MesosTest(unittest.TestCase):
         with requests_mock.Mocker(real_http=True) as m:
             tasks_api = [
                 {
-                   "taskId":{
-                      "requestId":"my-request",
-                      "deployId":"teamcity_2018_01_17T00_04_40",
-                      "startedAt":1516147481669,
-                      "instanceNo":2,
-                      "host":"mesos_slave21_qa_sf.qasql.opentable.com",
-                      "sanitizedHost":"mesos_slave21_qa_sf.qasql.opentable.com",
-                      "sanitizedRackId":"FIXME",
-                      "rackId":"FIXME",
-                      "id":"my-mesos-task"
+                   "taskId": {
+                      "requestId": "my-request",
+                      "deployId": "teamcity_2018_01_17T00_04_40",
+                      "startedAt": 1516147481669,
+                      "instanceNo": 2,
+                      "host": "mesos_slave21_qa_sf.qasql.opentable.com",
+                      "sanitizedHost": "mesos_slave21_qa_sf.qasql.opentable.com",
+                      "sanitizedRackId": "FIXME",
+                      "rackId": "FIXME",
+                      "id": "my-mesos-task"
                    },
-                   "mesosTask":{
-                      "taskId":{
-                         "value":"my-mesos-task"
+                   "mesosTask": {
+                      "taskId": {
+                         "value": "my-mesos-task"
                       },
-                      "name":"pp-promoted-inventory-service",
+                      "name": "pp-promoted-inventory-service",
                     }
                 }
             ]
@@ -263,9 +265,7 @@ class MesosTest(unittest.TestCase):
 
             try:
                 self.assertEqual(len(q.qsize()), 5)
-            except NotImplementedError: # Not supported in Mac OS X
+            except NotImplementedError:  # Not supported in Mac OS X
                 pass
             a = q.get()
             self.assertTrue(a.split()[0].startswith('tasks.my-request_2.'))
-
-

--- a/test/mesos_test.py
+++ b/test/mesos_test.py
@@ -1,0 +1,99 @@
+import time
+import unittest
+import requests
+import requests_mock
+
+from mesos_stats.mesos import Mesos, MesosStatsException
+
+'''
+import sys
+import logging
+logger = logging.getLogger()
+logger.level = logging.DEBUG
+stream_handler = logging.StreamHandler(sys.stdout)
+logger.addHandler(stream_handler)
+'''
+
+class MesosTest(unittest.TestCase):
+    def setUp(self):
+        self.slaves_api = {
+            'slaves': [
+                {
+                    'hostname': 'slave1',
+                    'port': '5051',
+                }
+            ]
+        }
+
+
+    def test_mesos_raises_exception_for_no_master(self):
+        master_list = ['mesos4', 'mesos5', 'mesos6']
+        self.assertRaises(MesosStatsException, Mesos, master_list)
+
+
+    def test_mesos_chooses_working_master(self):
+        with requests_mock.Mocker(real_http=True) as m:
+            m.register_uri('GET', 'http://mesos2/slaves',
+                           json=self.slaves_api, status_code=200)
+            m.register_uri('GET', 'http://mesos2/version',
+                           json={'a': 'b'}, status_code=200)
+            mesos = Mesos(master_list=['mesos1', 'mesos2', 'mesos3'])
+        self.assertEqual(mesos.master, 'mesos2')
+
+
+    def test_get_slave_metrics(self):
+        with requests_mock.Mocker(real_http=True) as m:
+            res = {
+                "slave/tasks_finished": 4367,
+                "slave/cpus_total": 32,
+                "slave/executors_preempted": 0,
+            }
+            m.register_uri('GET', 'http://slave1:5051/metrics/snapshot',
+                           json=res, status_code=200)
+            m.register_uri('GET', 'http://mesos1/slaves',
+                           json=self.slaves_api, status_code=200)
+            m.register_uri('GET', 'http://mesos1/version',
+                           json={'a': 'b'}, status_code=200)
+            mesos = Mesos(master_list=['mesos1'])
+            slave_metrics = mesos._get_slave_metrics()
+
+            self.assertTrue(isinstance(slave_metrics, dict))
+            self.assertTrue('slave1' in slave_metrics.keys())
+            self.assertTrue(isinstance(slave_metrics['slave1'], dict))
+            self.assertTrue(slave_metrics['slave1']['slave/cpus_total'], 32)
+
+
+    def test_get_executors(self):
+        with requests_mock.Mocker(real_http=True) as m:
+            res = [
+                {
+                    "executor_id": "mytask",
+                    "executor_name": "mytask command",
+                    "framework_id": "Singularity",
+                    "source": "mytask",
+                    "statistics": {
+                        "cpus_limit": 0.13,
+                        "cpus_system_time_secs": 22.56,
+                        "cpus_user_time_secs": 104.88,
+                        "mem_limit_bytes": 301989888,
+                        "mem_rss_bytes": 87113728,
+                        "timestamp": 1516124496.89259
+                    }
+                }
+            ]
+            m.register_uri('GET', 'http://slave1:5051/monitor/statistics.json',
+                           json=res, status_code=200)
+            m.register_uri('GET', 'http://mesos1/slaves',
+                           json=self.slaves_api, status_code=200)
+            m.register_uri('GET', 'http://mesos1/version',
+                           json={'a': 'b'}, status_code=200)
+            mesos = Mesos(master_list=['mesos1'])
+            executors = mesos._get_executors()
+
+            self.assertTrue(isinstance(executors, dict))
+            self.assertTrue('slave1' in executors.keys())
+            self.assertTrue(isinstance(executors['slave1'], list))
+            self.assertEqual(executors['slave1'][0]['executor_id'], "mytask")
+
+
+

--- a/test/singularity_test.py
+++ b/test/singularity_test.py
@@ -1,0 +1,147 @@
+import unittest
+import requests
+import requests_mock
+
+from mesos_stats.singularity import Singularity, SingularityCarbon
+
+class MesosTest(unittest.TestCase):
+    def setUp(self):
+        self.state_api = {
+            "activeTasks": 817,
+            "launchingTasks": 0,
+            "activeRequests": 654,
+            "cooldownRequests": 7,
+            "pausedRequests": 58,
+            "scheduledTasks": 72,
+            "pendingRequests": 0,
+            "lbCleanupTasks": 0,
+            "lbCleanupRequests": 0,
+            "cleaningRequests": 0,
+            "activeSlaves": 28,
+            "deadSlaves": 0,
+            "decommissioningSlaves": 1,
+            "activeRacks": 1,
+            "deadRacks": 0,
+            "decommissioningRacks": 0,
+            "cleaningTasks": 0,
+            "oldestDeploy": 2062,
+            "numDeploys": 1,
+            "oldestDeployStep": 2062,
+            "lateTasks": 0,
+            "futureTasks": 72,
+            "maxTaskLag": 0,
+            "generatedAt": 1516279668086,
+            "overProvisionedRequests": 0,
+            "underProvisionedRequests": 1,
+            "finishedRequests": 0,
+            "unknownRacks": 0,
+            "unknownSlaves": 0,
+            "authDatastoreHealthy": 'true',
+            "avgStatusUpdateDelayMs": 0,
+            "decomissioningSlaves": 1,
+            "decomissioningRacks": 0,
+            "allRequests": 719
+        }
+
+        self.disaster_api = {
+            "stats": [
+                {
+                    "timestamp": 1516279808269,
+                    "numActiveTasks": 833,
+                    "numPendingTasks": 56,
+                    "numLateTasks": 0,
+                    "avgTaskLagMillis": 0,
+                    "numLostTasks": 0,
+                    "numActiveSlaves": 29,
+                    "numLostSlaves": 0
+                },
+                {
+                    "timestamp": 1516279798264,
+                    "numActiveTasks": 817,
+                    "numPendingTasks": 72,
+                    "numLateTasks": 0,
+                    "avgTaskLagMillis": 0,
+                    "numLostTasks": 0,
+                    "numActiveSlaves": 29,
+                    "numLostSlaves": 0
+                },
+            ],
+        }
+
+        self.requests_api = [
+            {
+                "request": {
+                    "id": "pp-freetext-api",
+                    "requestType": "SERVICE",
+                    "owners": [
+                        "user@mail.com",
+                    ],
+                    "instances": 1
+                },
+                "state": "ACTIVE",
+                "requestDeployState": {
+                    "requestId": "pp-freetext-api",
+                    "activeDeploy": {
+                        "requestId": "pp-freetext-api",
+                        "deployId": "teamcity_2018_01_17T01_28_48",
+                        "timestamp": 1516152528958
+                    }
+                }
+            },
+            {
+                "request": {
+                    "id": "coresvc_cancel_queue--eu-pp_sf-6288de",
+                    "requestType": "SERVICE",
+                    "owners": [
+                        "user@mail.com",
+                    ],
+                    "instances": 1
+                },
+                "state": "ACTIVE",
+                "requestDeployState": {
+                    "requestId": "coresvc_cancel_queue--eu-pp_sf-6288de",
+                    "pendingDeploy": {
+                        "requestId": "coresvc_cancel_queue--eu-pp_sf-6288de",
+                        "deployId": "1_0_22_60df718d2136416c80e8d504ed9f6002",
+                        "timestamp": 1516279862745
+                    }
+                }
+            },
+
+        ]
+
+
+    def test_singularity_carbon(self):
+        with requests_mock.Mocker(real_http=True) as m:
+            m.register_uri('GET', 'http://server/api/state',
+                           json=self.state_api, status_code=200)
+            m.register_uri('GET', 'http://server/api/requests',
+                           json=self.requests_api, status_code=200)
+            m.register_uri('GET', 'http://server/api/disasters/stats',
+                           json=self.disaster_api, status_code=200)
+            s = Singularity('server')
+            q = []
+            sc = SingularityCarbon(s, q)
+            sc.flush_metrics()
+
+            # Queue should be populated
+            self.assertTrue(q)
+
+            # Test plaintext protocol
+            self.assertEqual(len(q[0].split()), 3)
+
+            # Make sure that every metric has been captured
+            all_metric_names = set(sc.metric_mapping.values())
+            metric_names_from_q = set([m.split()[0] for m in q])
+            self.assertEqual(all_metric_names, metric_names_from_q)
+
+            # Test pickle protocol
+            q2 = []
+            sc2 = SingularityCarbon(s, q2, pickle=True)
+            sc2.flush_metrics()
+
+            self.assertTrue(q2)
+            self.assertIsInstance(q2[0], tuple)
+            self.assertIsInstance(q2[0][1], tuple)
+
+


### PR DESCRIPTION
DO NOT MERGE YET.

- New metrics added

- Improved mapping from task names to requests ID

- Slave names are now actual hostnames instead of slave.slave_1__192_168_217_100:5051

- Able to handle if a master goes down. It accepts a list of master hosts and will retry each one. In the event that a master goes down, we will just need to restart mesos_stats.

- Lower memory usage - Changed from multi process to mult-threaded metrics collection

- Lots of tests !
