### PR TITLE
Instance number should really be a separate directory in storage, so you can wildcard efficiently

### DIFF
--- a/mesos_stats/mesos.py
+++ b/mesos_stats/mesos.py
@@ -215,7 +215,7 @@ def new_slave_task_metrics(mesos, requests_json=None):
 
                     instance_no = t['executor_id'].split('-mesos-slave', 1)[0][-1]
 
-                task = "{}_{}".format(task_name, instance_no)
+                task = "{}.{}".format(task_name, instance_no)
                 m.Add(t["statistics"], [task,])
     num_metrics = sum([len(m.data) for m in tc_metrics])
     log('Number of new-style task metrics : {}'.format(num_metrics))


### PR DESCRIPTION
This may well be an unacceptable change to make at this point, but I figured I'd open it for discussion